### PR TITLE
[fix] Backend CORS 설정에 프로덕션 도메인 추가

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -17,11 +17,22 @@ class Settings(BaseSettings):
     # Gemini API (Secret Manager에서 주입)
     gemini_api_key: str = os.getenv("GEMINI_API_KEY", "")
     
-    # CORS
-    allowed_origins: list[str] = [
-        "http://localhost:3000",
-        "https://localhost:3000",
-    ]
+    # CORS - 프로덕션 도메인은 환경변수로 추가 가능
+    cors_extra_origins: str = os.getenv("CORS_EXTRA_ORIGINS", "")
+    
+    @property
+    def allowed_origins(self) -> list[str]:
+        """CORS allowed origins - 기본값 + 환경변수 추가"""
+        origins = [
+            "http://localhost:3000",
+            "http://localhost:3002",
+            "https://localhost:3000",
+        ]
+        # 환경변수에서 추가 도메인 로드 (쉼표로 구분)
+        if self.cors_extra_origins:
+            extra = [o.strip() for o in self.cors_extra_origins.split(",") if o.strip()]
+            origins.extend(extra)
+        return origins
     
     # Firebase (프로젝트 ID만 - 키는 환경변수)
     firebase_project_id: str = os.getenv("GOOGLE_CLOUD_PROJECT", "")


### PR DESCRIPTION
## 개요
프로덕션 환경에서 CORS 오류를 방지하기 위해 환경변수 기반 도메인 설정을 추가합니다.

## 변경사항
- CORS_EXTRA_ORIGINS 환경변수로 프로덕션 도메인 추가 가능
- 하드코딩된 도메인 대신 환경변수 사용으로 보안 강화
- localhost:3002 개발 포트 추가

## 테스트
- [x] 로컬 환경 테스트
- [ ] 프로덕션 배포 테스트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CORS configuration to support additional allowed origins via environment variable.
  * Updated default allowed origins configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->