### PR TITLE
[chore] .gitignore에 Firebase 빌드 캐시 추가

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# firebase
+.firebase/


### PR DESCRIPTION
## 개요
Firebase 빌드 캐시 디렉토리를 gitignore에 추가하여 불필요한 파일이 커밋되지 않도록 합니다.

## 변경사항
- `.firebase/` 디렉토리를 gitignore에 추가